### PR TITLE
Fixed Github CLI parameter handling

### DIFF
--- a/dist/actions.js
+++ b/dist/actions.js
@@ -23508,16 +23508,19 @@ async function listCommits({ host, jq, ...options }) {
 }
 
 // dist/dnt/esm/gh-wrapper/list_tags.js
-function createUrl2({ owner, repo, perPage, page }) {
-  const param = new URLSearchParams();
+function createUrl2({ owner, repo }) {
+  return `repos/${owner}/${repo}/tags`;
+}
+function getPageParams({ perPage, page }) {
+  const params = [];
   if (perPage)
-    param.set("per_page", String(perPage));
+    params.push(`-F per_page=${perPage}`);
   if (page)
-    param.set("page", String(page));
-  return `repos/${owner}/${repo}/tags?${param}`;
+    params.push(`-F page=${page}`);
+  return params;
 }
 async function listTags({ host, jq, ...options }) {
-  const args = ["api", createUrl2(options)];
+  const args = ["api", "-XGET", createUrl2(options), ...getPageParams(options)];
   if (host)
     args.push("--hostname", host);
   if (jq)

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -10321,16 +10321,19 @@ async function listCommits({ host, jq, ...options }) {
 }
 
 // dist/dnt/esm/gh-wrapper/list_tags.js
-function createUrl2({ owner, repo, perPage, page }) {
-  const param = new URLSearchParams();
+function createUrl2({ owner, repo }) {
+  return `repos/${owner}/${repo}/tags`;
+}
+function getPageParams({ perPage, page }) {
+  const params = [];
   if (perPage)
-    param.set("per_page", String(perPage));
+    params.push(`-F per_page=${perPage}`);
   if (page)
-    param.set("page", String(page));
-  return `repos/${owner}/${repo}/tags?${param}`;
+    params.push(`-F page=${page}`);
+  return params;
 }
 async function listTags({ host, jq, ...options }) {
-  const args = ["api", createUrl2(options)];
+  const args = ["api", "-XGET", createUrl2(options), ...getPageParams(options)];
   if (host)
     args.push("--hostname", host);
   if (jq)

--- a/gh-wrapper/list_tags.ts
+++ b/gh-wrapper/list_tags.ts
@@ -30,15 +30,20 @@ function createUrl(
   {
     owner,
     repo,
+  }: ListTagsOption,
+): string {
+  return `repos/${owner}/${repo}/tags`;
+}
+function getPageParams(
+  {
     perPage,
     page,
   }: ListTagsOption,
-): string {
-  const param = new URLSearchParams();
-  if (perPage) param.set("per_page", String(perPage));
-  if (page) param.set("page", String(page));
-
-  return `repos/${owner}/${repo}/tags?${param}`;
+): string[] {
+  const params = [];
+  if (perPage) params.push(`-F per_page=${perPage}`);
+  if (page) params.push(`-F page=${page}`);
+  return params;
 }
 
 /**
@@ -51,7 +56,7 @@ export async function listTags(
     ...options
   }: ListTagsOption & GitHubCliOptions,
 ): Promise<string> {
-  const args = ["api", createUrl(options)];
+  const args = ["api", "-XGET", createUrl(options), ...getPageParams(options)];
   if (host) args.push("--hostname", host);
   if (jq) args.push("-q", jq);
 


### PR DESCRIPTION
Fixes an issue where fetching tags would end up in an infinite loop when the repo has more than 100 tags