### PR TITLE
🐛 Fix handling of multiple tags on the same commit to keep the newest tag

### DIFF
--- a/core/fetch_tags.test.ts
+++ b/core/fetch_tags.test.ts
@@ -41,4 +41,34 @@ Deno.test("async function fetchTags(args)", async (ctx) => {
       assertEquals(callCount, 2);
     },
   );
+
+  await ctx.step(
+    "#115: Multiple tags on same commit should keep newest tag",
+    async () => {
+      const mockListTags = (options: ListTagsOption) => {
+        if (options.page === 1) {
+          // GitHub API returns tags newest-first
+          const tags = [
+            { commit: { sha: "aaa" }, name: "v0.0.7" },
+            { commit: { sha: "aaa" }, name: "v0.0.6" },
+            { commit: { sha: "bbb" }, name: "v0.0.5" },
+          ];
+          return tags.map((tag) => JSON.stringify([tag.commit.sha, tag.name]))
+            .join("\n");
+        }
+        return "";
+      };
+
+      const result = await fetchTags({
+        owner: "test",
+        repo: "repo",
+        listTagsFn: mockListTags,
+      });
+
+      // Same SHA "aaa" has two tags; newest (v0.0.7) should be kept
+      assertEquals(result.get("aaa"), "v0.0.7");
+      assertEquals(result.get("bbb"), "v0.0.5");
+      assertEquals(result.size, 2);
+    },
+  );
 });

--- a/core/fetch_tags.ts
+++ b/core/fetch_tags.ts
@@ -46,7 +46,9 @@ export async function fetchTags(
     exclude: toReqExpArray(exclude),
   };
 
-  const tags: [sha: string, name: string][] = [];
+  // GitHub API returns tags in newest-first order.
+  // When multiple tags point to the same commit, keep the first (newest) one.
+  const tags = new Map<string, string>();
   const perPage = 100;
   const jq = ".[] | [.commit.sha, .name]";
   let page = 0;
@@ -55,7 +57,11 @@ export async function fetchTags(
     page++;
     const stdout = await listTagsFn({ owner, repo, perPage, page, host, jq });
     tuples = parseTags(stdout, context);
-    tags.push(...tuples);
+    for (const [sha, name] of tuples) {
+      if (!tags.has(sha)) {
+        tags.set(sha, name);
+      }
+    }
   } while (tuples.length === perPage);
-  return new Map(tags);
+  return tags;
 }

--- a/dist/actions.js
+++ b/dist/actions.js
@@ -24891,7 +24891,7 @@ async function fetchTags({ owner, repo, host, match, exclude, listTagsFn = listT
     match: toReqExpArray(match),
     exclude: toReqExpArray(exclude)
   };
-  const tags = [];
+  const tags = /* @__PURE__ */ new Map();
   const perPage = 100;
   const jq = ".[] | [.commit.sha, .name]";
   let page = 0;
@@ -24900,9 +24900,13 @@ async function fetchTags({ owner, repo, host, match, exclude, listTagsFn = listT
     page++;
     const stdout = await listTagsFn({ owner, repo, perPage, page, host, jq });
     tuples = parseTags(stdout, context);
-    tags.push(...tuples);
+    for (const [sha, name] of tuples) {
+      if (!tags.has(sha)) {
+        tags.set(sha, name);
+      }
+    }
   } while (tuples.length === perPage);
-  return new Map(tags);
+  return tags;
 }
 
 // dist/dnt/esm/core/fetch_total_commit.js

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -10437,7 +10437,7 @@ async function fetchTags({ owner, repo, host, match, exclude, listTagsFn = listT
     match: toReqExpArray(match),
     exclude: toReqExpArray(exclude)
   };
-  const tags = [];
+  const tags = /* @__PURE__ */ new Map();
   const perPage = 100;
   const jq = ".[] | [.commit.sha, .name]";
   let page = 0;
@@ -10446,9 +10446,13 @@ async function fetchTags({ owner, repo, host, match, exclude, listTagsFn = listT
     page++;
     const stdout = await listTagsFn({ owner, repo, perPage, page, host, jq });
     tuples = parseTags(stdout, context);
-    tags.push(...tuples);
+    for (const [sha, name] of tuples) {
+      if (!tags.has(sha)) {
+        tags.set(sha, name);
+      }
+    }
   } while (tuples.length === perPage);
-  return new Map(tags);
+  return tags;
 }
 
 // dist/dnt/esm/core/fetch_total_commit.js


### PR DESCRIPTION
When multiple tags share the same commit SHA, keep the first (newest) tag from the GitHub API instead of letting older tags overwrite it in the Map. Fixes #115.