### PR TITLE
⬆️ Update to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Use Deno
         uses: denoland/setup-deno@v2
@@ -57,10 +57,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Use Deno
         uses: denoland/setup-deno@v2
@@ -95,10 +95,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 20
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Use Deno
         uses: denoland/setup-deno@v2

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ outputs:
       ex) 2414721
 
 runs:
-  using: node20
+  using: node24
   main: dist/actions.js
 
 branding:


### PR DESCRIPTION
## Overview

This PR upgrades gh-describe to run on Node.js 24, addressing the deprecation of Node 20 on GitHub Actions.

## Changes

- Update `action.yml` to use `node24` instead of `node20`
- Update all workflow jobs in `.github/workflows/build.yml` to use Node.js 24

## Related Issue

Closes #112

## Breaking Change

This update requires Node.js 24+, which is necessary due to GitHub's deprecation timeline for Node 20 (EOL April 2026, deprecated June 2 2026).